### PR TITLE
Get image from cravatar over https, to prevent 301 redirect messing up image download

### DIFF
--- a/src/com/vauff/maunzdiscord/commands/AccInfo.java
+++ b/src/com/vauff/maunzdiscord/commands/AccInfo.java
@@ -75,7 +75,7 @@ public class AccInfo extends AbstractCommand<MessageReceivedEvent>
 						uuid = new StringBuilder(uuid).insert(uuid.length() - 16, "-").toString();
 						uuid = new StringBuilder(uuid).insert(uuid.length() - 12, "-").toString();
 
-						String headURL = "http://cravatar.eu/helmavatar/" + status[1] + "/120";
+						String headURL = "https://cravatar.eu/helmavatar/" + status[1] + "/120";
 						EmbedObject embed = new EmbedBuilder().withColor(Util.averageColorFromURL(new URL(headURL))).withThumbnail(headURL).appendField("Name", status[1], true).withFooterText("Powered by axis.iaero.me").appendField("Account Status", "Premium", true).appendField("Migrated", StringUtils.capitalize(status[2]), true).appendField("UUID", uuid, true).appendField("Skin", "https://minotar.net/body/" + status[1] + "/500.png", true).appendField("Raw Skin", "https://minotar.net/skin/" + status[1], true).build();
 						Util.msg(event.getChannel(), event.getAuthor(), embed);
 					}


### PR DESCRIPTION
Cravatar probably started redirecting http traffic to https by returning a 301 redirect statuscode. 
Browsers will actually redirect themselves to the correct page, but it seems like ImageIO is not smart enough to do this. 
Instead it fails because the response does not have an image body, making it return null.