### PR TITLE
Fix NullPointerException in services menu

### DIFF
--- a/src/com/vauff/maunzdiscord/commands/servicesmenu/add/AddServicePage.java
+++ b/src/com/vauff/maunzdiscord/commands/servicesmenu/add/AddServicePage.java
@@ -37,6 +37,7 @@ public class AddServicePage extends AbstractServiceActionPage
 		{
 			Util.msg(trigger.getChannel(), "There are no more services to add!");
 			end();
+			return;
 		}
 
 		super.show();

--- a/src/com/vauff/maunzdiscord/core/AbstractMenuPage.java
+++ b/src/com/vauff/maunzdiscord/core/AbstractMenuPage.java
@@ -136,7 +136,10 @@ public abstract class AbstractMenuPage
 			removeTimer.cancel(false);
 		}
 
-		menu.delete();
+		if(menu != null)
+		{
+			menu.delete();
+		}
 	}
 
 	/**


### PR DESCRIPTION
An NPE occurs when selecting "Add New Service" while there are no new services to add. This PR fixes that.