### PR TITLE
Fix equality check in MessageCreateThread

### DIFF
--- a/src/com/vauff/maunzdiscord/core/AbstractCommand.java
+++ b/src/com/vauff/maunzdiscord/core/AbstractCommand.java
@@ -16,7 +16,7 @@ public abstract class AbstractCommand<M extends MessageCreateEvent>
 	 * The values hold an instance of {@link Await}
 	 */
 	public static final HashMap<Snowflake, Await> AWAITED = new HashMap<>();
-	public static final HashMap<Snowflake, String> AWAITEDCHANNEL = new HashMap<>();
+	public static final HashMap<Snowflake, Snowflake> AWAITEDCHANNEL = new HashMap<>();
 
 	/**
 	 * Executes this command


### PR DESCRIPTION
The second check in this line https://github.com/Vauff/Maunz-Discord/blob/57f72feb51bfaee353e534f8bd348ddc868e427c/src/com/vauff/maunzdiscord/threads/MessageCreateThread.java#L143 is erroneous, as comparing a `Snowflake` to a `String` will always yield false, hence the if statement will also always evaluate to false. Changing the definition of AWAITEDCHANNEL to use a `Snowflake` instead of a `String` as a value fixes this.
This change does not affect anything in the bot, as the field in question is not used for anything.