### PR TITLE
Autocomplete Implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,5 +94,10 @@
             <artifactId>mongodb-driver-sync</artifactId>
             <version>5.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>me.xdrop</groupId>
+            <artifactId>fuzzywuzzy</artifactId>
+            <version>1.3.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/com/vauff/maunzdiscord/commands/Notify.java
+++ b/src/com/vauff/maunzdiscord/commands/Notify.java
@@ -517,8 +517,8 @@ public class Notify extends AbstractCommand<ChatInputInteractionEvent>
 	private int mapWeightRatio(String target, String mapMatching){
 		final long mapLatest = cachedPlayedMaps.get(mapMatching);
 		final long now = System.currentTimeMillis();
-		final int similarity = FuzzySearch.tokenSortPartialRatio(target, mapMatching);
-		final float played = (float) (now - mapLatest) / (now - oldestMapPlayed);
+		final int similarity = FuzzySearch.tokenSetRatio(target, mapMatching);
+		final float played = (float) (mapLatest - oldestMapPlayed) / (now - oldestMapPlayed);
 		return (int) Math.round((((similarity / 100.0) * .8) + (played * 0.2)) * 100);
 	}
 }

--- a/src/com/vauff/maunzdiscord/commands/templates/AbstractCommand.java
+++ b/src/com/vauff/maunzdiscord/commands/templates/AbstractCommand.java
@@ -217,24 +217,37 @@ public abstract class AbstractCommand<M extends ChatInputInteractionEvent>
 		Util.editReply(event, formattedTitle + elementsString, null, buttonRows);
 	}
 	private static boolean exhaustAutocompleteOptions(ApplicationCommandOptionData option){
+		if (option.options().isAbsent()){
+			if(!option.autocomplete().isAbsent()){
+				return option.autocomplete().get();
+			}
+			return false;
+		}
 		for (ApplicationCommandOptionData opt : option.options().get()){
 			boolean hasAutocomplete = false;
 			if (!opt.options().isAbsent())
 				hasAutocomplete = exhaustAutocompleteOptions(opt);
-			if (!opt.autocomplete().isAbsent())
-				hasAutocomplete |= opt.autocomplete().get();
+			else if (!opt.autocomplete().isAbsent())
+				hasAutocomplete = opt.autocomplete().get();
 			if (hasAutocomplete)
 				return true;
 		}
 
 		return false;
 	}
-	public boolean hasAutocomplete(){
+	private Boolean autocomplete = null;
+	public final boolean hasAutocomplete(){
+		if (autocomplete == null)
+			autocomplete = containAutocomplete();
+
+		return autocomplete;
+	}
+	public boolean containAutocomplete(){
 		if (getCommandRequest().options().isAbsent())
 			return false;
 
 		for (ApplicationCommandOptionData option : getCommandRequest().options().get()){
-			if (!exhaustAutocompleteOptions(option))
+			if (exhaustAutocompleteOptions(option))
 				return true;
 		}
 		return false;

--- a/src/com/vauff/maunzdiscord/commands/templates/AbstractCommand.java
+++ b/src/com/vauff/maunzdiscord/commands/templates/AbstractCommand.java
@@ -5,14 +5,18 @@ import com.vauff.maunzdiscord.core.Util;
 import com.vauff.maunzdiscord.objects.Await;
 import discord4j.common.util.Snowflake;
 import discord4j.core.event.domain.interaction.ButtonInteractionEvent;
+import discord4j.core.event.domain.interaction.ChatInputAutoCompleteEvent;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import discord4j.core.event.domain.interaction.DeferrableInteractionEvent;
+import discord4j.core.object.command.ApplicationCommandInteractionOption;
 import discord4j.core.object.component.ActionRow;
 import discord4j.core.object.component.Button;
 import discord4j.core.object.component.LayoutComponent;
 import discord4j.core.object.entity.User;
 import discord4j.core.object.entity.channel.MessageChannel;
 import discord4j.discordjson.json.ApplicationCommandData;
+import discord4j.discordjson.json.ApplicationCommandOptionChoiceData;
+import discord4j.discordjson.json.ApplicationCommandOptionData;
 import discord4j.discordjson.json.ApplicationCommandRequest;
 
 import java.util.ArrayList;
@@ -211,5 +215,31 @@ public abstract class AbstractCommand<M extends ChatInputInteractionEvent>
 			buttonRows.add(ActionRow.of(pageButtons));
 
 		Util.editReply(event, formattedTitle + elementsString, null, buttonRows);
+	}
+	private static boolean exhaustAutocompleteOptions(ApplicationCommandOptionData option){
+		for (ApplicationCommandOptionData opt : option.options().get()){
+			boolean hasAutocomplete = false;
+			if (!opt.options().isAbsent())
+				hasAutocomplete = exhaustAutocompleteOptions(opt);
+			if (!opt.autocomplete().isAbsent())
+				hasAutocomplete |= opt.autocomplete().get();
+			if (hasAutocomplete)
+				return true;
+		}
+
+		return false;
+	}
+	public boolean hasAutocomplete(){
+		if (getCommandRequest().options().isAbsent())
+			return false;
+
+		for (ApplicationCommandOptionData option : getCommandRequest().options().get()){
+			if (!exhaustAutocompleteOptions(option))
+				return true;
+		}
+		return false;
+	}
+	public List<ApplicationCommandOptionChoiceData> autoComplete(ChatInputAutoCompleteEvent event, ApplicationCommandInteractionOption option, String currentText){
+		return new ArrayList<>();
 	}
 }

--- a/src/com/vauff/maunzdiscord/core/AutoCompleteListener.java
+++ b/src/com/vauff/maunzdiscord/core/AutoCompleteListener.java
@@ -13,9 +13,9 @@ import java.util.List;
 public class AutoCompleteListener {
     public static Mono<Void> process(ChatInputAutoCompleteEvent event){
         AbstractCommand<ChatInputInteractionEvent> command = Main.commands.get(event.getCommandName());
-        if (command == null){
+        if (command == null)
             return null;
-        }
+
         if (!command.hasAutocomplete())
             return null;
 

--- a/src/com/vauff/maunzdiscord/core/AutoCompleteListener.java
+++ b/src/com/vauff/maunzdiscord/core/AutoCompleteListener.java
@@ -1,0 +1,34 @@
+package com.vauff.maunzdiscord.core;
+
+import com.vauff.maunzdiscord.commands.templates.AbstractCommand;
+import discord4j.core.event.domain.interaction.ChatInputAutoCompleteEvent;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import discord4j.core.object.command.ApplicationCommandInteractionOption;
+import discord4j.core.object.command.ApplicationCommandInteractionOptionValue;
+import discord4j.discordjson.json.ApplicationCommandOptionChoiceData;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public class AutoCompleteListener {
+    public static Mono<Void> process(ChatInputAutoCompleteEvent event){
+        AbstractCommand<ChatInputInteractionEvent> command = Main.commands.get(event.getCommandName());
+        if (command == null){
+            return null;
+        }
+        if (!command.hasAutocomplete())
+            return null;
+
+        ApplicationCommandInteractionOption option = event.getFocusedOption();
+        String current = option.getValue()
+                .map(ApplicationCommandInteractionOptionValue::asString)
+                .orElse("");
+        try{
+            List<ApplicationCommandOptionChoiceData> suggests = command.autoComplete(event, option, current);
+            return event.respondWithSuggestions(suggests);
+        }catch (Exception e){
+            Logger.log.error("AutocompleteError: " + e.getMessage());
+        }
+        return null;
+    }
+}

--- a/src/com/vauff/maunzdiscord/core/Main.java
+++ b/src/com/vauff/maunzdiscord/core/Main.java
@@ -12,6 +12,7 @@ import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.guild.GuildCreateEvent;
 import discord4j.core.event.domain.guild.GuildDeleteEvent;
 import discord4j.core.event.domain.interaction.ButtonInteractionEvent;
+import discord4j.core.event.domain.interaction.ChatInputAutoCompleteEvent;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import discord4j.core.object.entity.Guild;
 import discord4j.discordjson.json.ApplicationCommandData;
@@ -123,6 +124,7 @@ public class Main
 			gateway.on(ChatInputInteractionEvent.class, event -> Mono.fromRunnable(() -> MainListener.onChatInputInteraction(event))).subscribe();
 			gateway.on(ButtonInteractionEvent.class, event -> Mono.fromRunnable(() -> MainListener.onButtonInteraction(event))).subscribe();
 			gateway.on(GuildDeleteEvent.class, event -> Mono.fromRunnable(() -> MainListener.onGuildDelete(event))).subscribe();
+			gateway.on(ChatInputAutoCompleteEvent.class, AutoCompleteListener::process).subscribe();
 
 			Executors.newScheduledThreadPool(1).scheduleWithFixedDelay(MapImageTimer.timer, 0, 1, TimeUnit.HOURS);
 			Executors.newScheduledThreadPool(1).scheduleWithFixedDelay(PresenceTimer.timer, 2, 5, TimeUnit.MINUTES);

--- a/src/com/vauff/maunzdiscord/core/Util.java
+++ b/src/com/vauff/maunzdiscord/core/Util.java
@@ -10,6 +10,7 @@ import discord4j.core.object.entity.channel.MessageChannel;
 import discord4j.core.object.entity.channel.PrivateChannel;
 import discord4j.core.spec.EmbedCreateSpec;
 import discord4j.core.spec.MessageCreateMono;
+import discord4j.discordjson.json.ApplicationCommandOptionChoiceData;
 import discord4j.rest.http.client.ClientException;
 import discord4j.rest.util.AllowedMentions;
 import discord4j.rest.util.Color;
@@ -329,4 +330,17 @@ public class Util
 	{
 		return "Maunz-Discord " + Main.version;
 	}
+
+	public static final long MAP_AUTOCOMPLETE_CACHE_INVALIDATED = 60 * 10 * 1000;
+	public static final int FUZZY_LIMIT_CUTOFF = 75;
+	public static String getMapKey(String mapName){
+		return mapName.replace('_', ' ');
+	}
+	public static ApplicationCommandOptionChoiceData mapChoice(final String map){
+		return ApplicationCommandOptionChoiceData.builder()
+				.name(map)
+				.value(map)
+				.build();
+	}
+
 }


### PR DESCRIPTION
## Feature Added
- General autocomplete implementation for abstract command.
- Adding autocomplete on `/notify toggle <mapname>` and `/map <mapname>`.
- Using fuzzy search for searching maps on said option.
  - Using token set ratio for searching maps, this seems to perform the best while not being too abroad.
    - set = allows for word of any order, and allows duplicate words
    - not partial = stricter rule, require full char match in a word to get 100% similarity score.
  - Sorted by last played epoch, uses `(current map - minimum epoch) / (current time - minimum epoch)`
     - notify toggle has a weight of 20% to the overall weight. This is a rule of thumb, may need to change if necessary.
  - Example:
         - ze_lotr_mines_of_moria: "lotr moria", "moria lotr", "ze moria" = 100%
         - ze_chicken_lords_tower: "tower" = 100% (will match other maps with tower too)
    In this case, the similarity score weight would have 80%, at that point it is ranked by last played that contributes 20%. This would work for cases where it matches for maps that has multiple version with the same name, but ranked by recent played epoch.
  
## Thoughts
I was thinking of creating a whole option class handler specifically to handle autocomplete that way the autocomplete callbacks are per option instead of per command. However, I feel like we don't need that granularity of handling autocomplete.

As discussed, perhaps we could also start applying autocomplete for `server` params for better suggestions on maps but I haven't touched there yet since it would be a large change. It's a step forward at least. 
I also agree about making `server` as a required argument since optional arguments on the discord client 'hide' those optional params.
It is worth noting that the discord autocomplete feature only suggests values, so making `server` params with autocomplete would still require the command to validate the server that was given. 