### PR TITLE
division by 0 error for empty server

### DIFF
--- a/src/com/vauff/maunzdiscord/servertracking/ServerTrackingLoop.java
+++ b/src/com/vauff/maunzdiscord/servertracking/ServerTrackingLoop.java
@@ -96,7 +96,7 @@ public class ServerTrackingLoop implements Runnable
 				List<Document> serverDocs = Main.mongoDatabase.getCollection("servers").find(eq("enabled", true)).projection(new Document("ip", 1).append("port", 1)).into(new ArrayList<>());
 				List<Document> serviceDocs = null;
 				long startTime = System.currentTimeMillis();
-				long targetSleepTime = LOOP_TIME / serverDocs.size();
+				long targetSleepTime = LOOP_TIME / Math.max(serverDocs.size(), 1);
 				int iterCount = 0;
 
 				for (Document doc : serverDocs)


### PR DESCRIPTION
When creating a new database, running the bot without any server in the database would throw a division by 0 exception. As shown below.
```
10:33:04.939 [servertracking-mainloop] ERROR com.vauff.maunzdiscord.core.Main - 
java.lang.ArithmeticException: / by zero
	at com.vauff.maunzdiscord.servertracking.ServerTrackingLoop.run(ServerTrackingLoop.java:99) [classes/:?]
	at java.base/java.lang.Thread.run(Thread.java:833) [?:?]
```